### PR TITLE
Fixed .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@
 *.lck
 *.log
 *.cache*
-/echo/echo_lib/hdl
+/echo/echo_lib/ps
 /echo/echo_lib/modelsim


### PR DESCRIPTION
Was not tracking vhd files.
Now it stops tracking Precision Synthesis files